### PR TITLE
Add local config file for fish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 hub
+fish/config.local.fish

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -14,3 +14,10 @@ end
 
 rbenv rehash
 refresh-colors
+
+# Load custom settings for current user
+set local_settings_file ~/.config/fish/config.local.fish
+
+if test -f $local_settings_file
+   . $local_settings_file
+end


### PR DESCRIPTION
This comes in handy for other users, now we should be able to keep user specific things, like rbenv or chruby, in one file. While having commonalities in the main config.fish

@alexdavid check it
