### PR TITLE
Add feature: tmux tabs and splits open to PWD

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -46,9 +46,12 @@ bind-key Enter break-pane
 # and split windows and tabs open to your current directory
 unbind %
 unbind '"'
+unbind n
 bind-key v split-window -h -c "#{pane_current_path}"
 bind-key s split-window -c "#{pane_current_path}"
 bind c new-window -c "#{pane_current_path}"
+bind-key n new-window -c "#{pane_current_path}"
+
 
 # Make copy mode more like vi
 unbind [
@@ -62,14 +65,11 @@ bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
 
 
 # Move between windows
-unbind n
 unbind ,
 unbind .
 unbind l
 bind-key , previous-window
 bind-key . next-window
-bind-key n new-window
-
 
 
 # Status bar


### PR DESCRIPTION
Now when you create any type of split or tab, tmux will now to use the your
current diretory in that new tab or split.
