### PR TITLE
Prevent vim clearscreen

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -36,8 +36,8 @@ bind-key J resize-pane -D 10
 bind-key K resize-pane -U 10
 bind-key L resize-pane -R 10
 
-# Make C-space clear the screen
-bind-key C-space send-keys -R
+# Make C-space clear the screen unless in vim
+bind-key C-space run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$') || tmux send-keys -R"
 
 # Make Enter break a pane into a new window
 bind-key Enter break-pane


### PR DESCRIPTION
- This prevents the C-space C-space shortcut from working if vim is
  running in the active pane

@SnJedi
