### PR TITLE
Ignore configstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+configstore
 hub
 fish/config.local.fish


### PR DESCRIPTION
`~/.config/configstore` is created automatically by bower and yeoman

@SnJedi
