### PR TITLE
Generalize quickfix list shortcuts

### DIFF
--- a/vim/plugin/ag.vim
+++ b/vim/plugin/ag.vim
@@ -1,0 +1,2 @@
+let g:ag_apply_lmappings=0
+let g:ag_apply_qmappings=0

--- a/vim/shortcuts.vim
+++ b/vim/shortcuts.vim
@@ -35,6 +35,12 @@ nmap <leader>L :call Resize('l', 10, '>', '<')<CR>
 nmap <leader>J :call Resize('j', 10, '+', '-')<CR>
 nmap <leader>K :call Resize('j', 10, '-', '+')<CR>
 
+" Quickfix list mappings
+autocmd BufReadPost quickfix nnoremap <buffer> s <C-W><CR><C-w>K
+autocmd BufReadPost quickfix nnoremap <buffer> v <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
+autocmd BufReadPost quickfix nnoremap <buffer> t <C-w><CR><C-w>T
+autocmd BufReadPost quickfix nnoremap <buffer> T <C-w><CR><C-w>TgT<C-W><C-W>
+
 " Indenting
 vmap < <gv
 vmap > >gv


### PR DESCRIPTION
This PR disables Ag's default mappings in favor of global quickfix list shortcuts
- Allows use of shortcuts in other quickfix uses not just when using `:Ag`
- Uses standard shortcuts for split buffers used in the rest of the config (s = horizontal split, v = vertical split)

@SnJedi please review
