### PR TITLE
Restore `gd` functionality

### DIFF
--- a/vim/shortcuts.vim
+++ b/vim/shortcuts.vim
@@ -53,7 +53,8 @@ autocmd InsertLeave * call DiffUpdate()
 noremap <leader>g :diffget 0 \| diffupdate<CR>
 noremap <leader>p :diffput 0 \| diffupdate<CR>
 nmap gk :Gitv --all<CR>:NERDTreeClose<CR>
-nmap gd :Gdiff HEAD<CR><C-W>l:Gdiff<CR>
+nmap gd :Gdiff<CR>
+nmap g3d :Gdiff HEAD<CR><C-W>l:Gdiff<CR>
 nmap gs :Gstatus<CR>:<CR><C-W>K
 nmap gc :Gcommit<CR>:set spell<CR><C-W>Ki
 nmap git :Git 


### PR DESCRIPTION
- Makes `gd` only run `:Gdiff` again
- Adds `g3d` shortcut for the 3-way diff

@SnJedi please review
