### PR TITLE
Extendable config.fish

### DIFF
--- a/fish/.gitignore
+++ b/fish/.gitignore
@@ -1,3 +1,2 @@
-config.local.fish
 fish_history
 fishd.*

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -16,7 +16,7 @@ rbenv rehash
 refresh-colors
 
 # Load custom settings for current user
-set local_settings_file ~/.config/fish/config.local.fish
+set local_settings_file ~/config.fish.local
 
 if test -f $local_settings_file
    . $local_settings_file


### PR DESCRIPTION
Add new way to extend config.fish
Change path to local config.fish and remove old path from gitignore.
