### PR TITLE
Force vimdiff colors to be the same for all colorschemes

### DIFF
--- a/vim/colorscheme.vim
+++ b/vim/colorscheme.vim
@@ -1,5 +1,8 @@
-" Use more contrasty colors for vimdiff
-let g:solarized_diffmode="high"
+" Force green/yellow/red colors for vimdiff
+hi! DiffAdd    ctermfg=193 ctermbg=65
+hi! DiffDelete ctermfg=234 ctermbg=9
+hi! DiffChange ctermfg=0   ctermbg=3
+hi! DiffText   ctermfg=234 ctermbg=11
 
 " Highlight trailing whitespace
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red


### PR DESCRIPTION
@seanstrom since we're no longer enforcing solarized, I'd like to force the vimdiff colors to always be red/yellow/green.

What do you think?
