### PR TITLE
set cindent in coffee files only.

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -25,7 +25,9 @@ set shiftwidth=2
 set softtabstop=2
 set ai " Autoindent
 set si " Smart indent
-set cindent
+
+" Fix indenting problems for coffee
+au FileType coffee set cindent
 
 
 " Appearance


### PR DESCRIPTION
There was a weird bug with javascript files needing a semicolon to
indent properly. No semicolons is an accepted style, so I fixed this bug.
