### PR TITLE
Add OSX key bindings

### DIFF
--- a/osx/DefaultKeyBinding.dict
+++ b/osx/DefaultKeyBinding.dict
@@ -1,0 +1,9 @@
+/* 
+* Copy this file to ~/Library/KeyBindings/DefaultKeyBinding.dict
+*/
+
+{
+  "^w" = "deleteWordBackward:";
+  "~f" = "moveWordForward:";
+  "~b" = "moveWordBackward:";
+}


### PR DESCRIPTION
Adds some of the missing emacs-style shortcuts that are available in vim and shells to OS X text inputs.
