### PR TITLE
Refactor init.sh into individual scripts

### DIFF
--- a/bash/init.sh
+++ b/bash/init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+# Create symlinks
+ln -s .config/bash/bashconfig ~/.bash_profile
+ln -s .config/bash/bashconfig ~/.bashrc

--- a/git/init.sh
+++ b/git/init.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+# Create symlinks
+ln -s .config/git/gitconfig ~/.gitconfig
+
+
+# Prompt for name and email for git commits
+full_name=$(finger $(whoami) | sed -e '/Name/!d;s/.*: //')
+read -p "Enter your name for git commits ($full_name): " git_user
+read -p "Enter your email for git commits: " git_email
+
+if [ -z "$git_user" ] then
+   git_user=$full_name
+fi
+
+echo "[user]" > ~/.config/git/gitconfig_user
+echo "  name = $git_user" >> ~/.config/git/gitconfig_user
+echo "  email = $git_email" >> ~/.config/git/gitconfig_user

--- a/init.sh
+++ b/init.sh
@@ -1,41 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-cd
-
-# Create symlinks
-ln -s .config/bash/bashconfig .bash_profile
-ln -s .config/bash/bashconfig .bashrc
-ln -s .config/git/gitconfig   .gitconfig
-ln -s .config/tmux/tmux.conf  .tmux.conf
-ln -s .config/vim/vimrc       .vimrc
-ln -s .config/zsh/zshrc       .zshrc
-
-# Create hushlogin
-touch .hushlogin
-
-
-# Prompt for name and email for git commits
-full_name=$(finger $(whoami) | sed -e '/Name/!d;s/.*: //')
-read -p "Enter your name for git commits ($full_name): " git_user
-read -p "Enter your email for git commits: " git_email
-
-if [ -z "$git_user" ]
-then
-   git_user=$full_name
-fi
+touch ~/.hushlogin
 
 cd ~/.config
-
-echo "[user]" > git/gitconfig_user
-echo "  name = $git_user" >> git/gitconfig_user
-echo "  email = $git_email" >> git/gitconfig_user
-
-# Prevent git from showing changes in files that update automatically
-git update-index --assume-unchanged vim/bundle/vundle
-git update-index --assume-unchanged colors
-
-# Install vim plugins
 git submodule init
 git submodule update
 git submodule foreach git checkout master
-vim +BundleInstall! +qall
+
+~/.config/bash/init.sh
+~/.config/git/init.sh
+~/.config/tmux/init.sh
+~/.config/vim/init.sh
+~/.config/zsh/init.sh

--- a/tmux/init.sh
+++ b/tmux/init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Create symlinks
+ln -s .config/tmux/tmux.conf ~/.tmux.conf

--- a/vim/init.sh
+++ b/vim/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Create symlinks
+ln -s .config/vim/vimrc ~/.vimrc
+
+# Install vim plugins
+vim +BundleInstall! +qall

--- a/zsh/init.sh
+++ b/zsh/init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Create symlinks
+ln -s .config/zsh/zshrc ~/.zshrc


### PR DESCRIPTION
@seanstrom While implementing n for switching node versions I realized it would be a lot cleaner to have individual init scripts for each configured service instead of having init.sh do everything.

This is also opens up the possibility of switching vundle from a submodule to just a clone step in vim's init script.
