### PR TITLE
Make C-space clear history in tmux

### DIFF
--- a/bin/tmux-clear
+++ b/bin/tmux-clear
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Don't clear screen if vim is running
+if [ $(tmux display-message -p "#{pane_current_command}") == vim ]; then exit; fi
+
+tmux send-keys -R
+tmux clear-history

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -39,8 +39,8 @@ bind-key J resize-pane -D 10
 bind-key K resize-pane -U 10
 bind-key L resize-pane -R 10
 
-# Make C-space clear the screen unless in vim
-bind-key C-space run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$') || tmux send-keys -R"
+# Make C-space clear the screen
+bind-key C-space run ~/.config/bin/tmux-clear
 
 # Make Enter break a pane into a new window
 bind-key Enter break-pane


### PR DESCRIPTION
@seanstrom 

This makes the C-space C-space shortcut in tmux also clear the scroll-back histroy which is useful before running a command that will have a lot of output (such as running tests) and you want to quickly be able to tell where in the history the command started.
