### PR TITLE
Add node config

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -4,6 +4,7 @@ touch ~/.hushlogin
 
 ~/.config/bash/init.sh
 ~/.config/git/init.sh
+~/.config/node/init.sh
 ~/.config/tmux/init.sh
 ~/.config/vim/init.sh
 ~/.config/zsh/init.sh

--- a/node/.gitignore
+++ b/node/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/node/init.sh
+++ b/node/init.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+cd ~/.config/node
+npm install

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "coffee-script": "latest",
+    "n": "latest"
+  }
+}

--- a/path
+++ b/path
@@ -12,6 +12,7 @@
 
 # Node.JS:
 ./node_modules/.bin
+~/.config/node/node_modules/.bin
 
 # System binaries:
 /usr/local/bin


### PR DESCRIPTION
Create `~/.config/node` as an alternative to globally installing node modules.

This keeps the path of your global node modules consistent across OS's.

@seanstrom what do you think?
